### PR TITLE
S allius/issue2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 ###
 # Overview
 
-The "TSUN Gen3 Micro-Inverter" proxy enables a reliable connection between TSUN third generation inverters and an MQTT broker to integrate the inverter into typical home automations.
+The "TSUN Gen3 Micro-Inverter" proxy enables a reliable connection between TSUN third generation inverters and an MQTT broker. With the proxy, you can easily retrieve real-time values such as power, current and daily energy and integrate the inverter into typical home automations. This works even without an internet connection. The optional connection to the TSUN Cloud can be disabled!
 
-The inverter establishes a TCP connection to the TSUN Cloud to transmit current measured values every 300 seconds. To be able to forward the measurement data to an MQTT broker, the proxy must be looped into this TCP connection.
+In detail, the inverter establishes a TCP connection to the TSUN cloud to transmit current measured values every 300 seconds. To be able to forward the measurement data to an MQTT broker, the proxy must be looped into this TCP connection.
 
 Through this, the inverter then establishes a connection to the proxy and the proxy establishes another connection to the TSUN Cloud. The transmitted data is interpreted by the proxy and then passed on to both the TSUN Cloud and the MQTT broker. The connection to the TSUN Cloud is optional and can be switched off in the configuration (default is on). Then no more data is sent to the Internet, but no more remote updates of firmware and operating parameters (e.g. rated power, grid parameters) are possible.
 
@@ -47,27 +47,27 @@ If you use a Pi-hole, you can also store the host entry in the Pi-hole.
 - A running Docker engine to host the container
 - Ability to loop the proxy into the connection between the inverter and the TSUN cloud
 
-## License
 
-This project is licensed under the [BSD 3-clause License](https://opensource.org/licenses/BSD-3-Clause).
+###
+# Getting Started
 
-Note the aiomqtt library used is based on the paho-mqtt library, which has a dual license. One of the licenses is the so-called [Eclipse Distribution License v1.0](https://www.eclipse.org/org/documents/edl-v10.php). It is almost word-for-word identical to the BSD 3-clause License. The only differences are:
-
-- One use of "COPYRIGHT OWNER" (EDL) instead of "COPYRIGHT HOLDER" (BSD)
-- One use of "Eclipse Foundation, Inc." (EDL) instead of "copyright holder" (BSD)
-
-
-## Versioning
-
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Breaking changes will only occur in major `X.0.0` releases.
-
-## Contributing
-
-We're very happy to receive contributions to this project! You can get started by reading [CONTRIBUTING.md](https://github.com/s-allius/tsun-gen3-proxy/blob/main/CONTRIBUTING.md).
-
-## Changelog
-
-The changelog lives in [CHANGELOG.md](https://github.com/s-allius/tsun-gen3-proxy/blob/main/CHANGELOG.md). It follows the principles of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+To run the proxy, you first need to create the image. You can do this quite simply as follows:
+```sh
+docker build https://github.com/s-allius/tsun-gen3-proxy.git#main:app -t tsun-proxy
+```
+after that you can run the image:
+```sh
+docker run  --dns '8.8.8.8' --env 'UID=1000' -p '5005:5005'  -v ./config:/home/tsun-proxy/config -v ./log:/home/tsun-proxy/log tsun-proxy
+```
+You will surely see a message that the configuration file was not found. So that we can create this without admin rights, the `uid` must still be adapted. To do this, simply stop the proxy with ctrl-c and use the `id` command to determine your own UserId: 
+```sh
+% id 
+uid=1050(sallius) gid=20(staff) ...
+```
+With this information we can customize the `docker run`` statement:
+```sh
+docker run  --dns '8.8.8.8' --env 'UID=1050' -p '5005:5005'  -v ./config:/home/tsun-proxy/config -v ./log:/home/tsun-proxy/log tsun-proxy
+```
 
 ###
 # Configuration
@@ -119,4 +119,26 @@ suggested_area = 'balcony'    # Optional, suggested installation area for home-a
 
 
 ```
+
+## License
+
+This project is licensed under the [BSD 3-clause License](https://opensource.org/licenses/BSD-3-Clause).
+
+Note the aiomqtt library used is based on the paho-mqtt library, which has a dual license. One of the licenses is the so-called [Eclipse Distribution License v1.0](https://www.eclipse.org/org/documents/edl-v10.php). It is almost word-for-word identical to the BSD 3-clause License. The only differences are:
+
+- One use of "COPYRIGHT OWNER" (EDL) instead of "COPYRIGHT HOLDER" (BSD)
+- One use of "Eclipse Foundation, Inc." (EDL) instead of "copyright holder" (BSD)
+
+
+## Versioning
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Breaking changes will only occur in major `X.0.0` releases.
+
+## Contributing
+
+We're very happy to receive contributions to this project! You can get started by reading [CONTRIBUTING.md](https://github.com/s-allius/tsun-gen3-proxy/blob/main/CONTRIBUTING.md).
+
+## Changelog
+
+The changelog lives in [CHANGELOG.md](https://github.com/s-allius/tsun-gen3-proxy/blob/main/CHANGELOG.md). It follows the principles of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,8 +1,19 @@
 ARG SERVICE_NAME="tsun-proxy"
 ARG UID=1000
+ARG GID=1000
 
 # set base image (host OS)
 FROM python:3.11-slim-bookworm AS builder
+
+USER root
+
+# install gosu for a better su+exec command
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y gosu; \
+	rm -rf /var/lib/apt/lists/*; \
+# verify that the binary works
+	gosu nobody true
 
 RUN pip install --upgrade pip
 
@@ -19,36 +30,51 @@ RUN pip install --user -r requirements.txt
 FROM python:3.11-slim-bookworm
 ARG SERVICE_NAME
 ARG UID
+ARG GID
 ENV SERVICE_NAME=$SERVICE_NAME
 ENV UID=$UID
+ENV GID=$GID 
 
-RUN addgroup --gid 1000 $SERVICE_NAME && \
+
+
+RUN addgroup --gid $GID $SERVICE_NAME && \
     adduser --ingroup $SERVICE_NAME --shell /bin/false --disabled-password --uid $UID $SERVICE_NAME && \
-    mkdir -p /home/$SERVICE_NAME/log && \
-    mkdir -p /home/$SERVICE_NAME/config && \
-    chown --recursive $SERVICE_NAME:$SERVICE_NAME /home/$SERVICE_NAME
-
+    mkdir -p /home/$SERVICE_NAME/log /home/$SERVICE_NAME/config && \
+    chown -R $SERVICE_NAME:$SERVICE_NAME /home/$SERVICE_NAME
+#addgroup -S -g 1883 mosquitto 2>/dev/null && \
+ #   adduser -S -u 1883 -D -H -h /var/empty -s /sbin/nologin -G mosquitto -g mosquitto mosquitto 2>/dev/null && \
+  #  mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
+  #  chown -R mosquitto:mosquitto /mosquitto && \
+    
 # set the working directory in the container
 WORKDIR /home/$SERVICE_NAME
-USER $SERVICE_NAME
-
-# copy only the dependencies installation from the 1st stage image
-COPY --from=builder --chown=$SERVICE_NAME:$SERVICE_NAME /root/.local /home/$SERVICE_NAME/.local
-
-# copy the content of the local src and config directory to the working directory
-COPY --chown=$SERVICE_NAME:$SERVICE_NAME config .
-COPY --chown=$SERVICE_NAME:$SERVICE_NAME src .
 
 # update PATH environment variable
 ENV HOME=/home/$SERVICE_NAME
 ENV PATH=/home/$SERVICE_NAME/.local:$PATH
 
+VOLUME ["/home/$SERVICE_NAME/log", "/home/$SERVICE_NAME/config"]
+
+# copy only the dependencies installation from the 1st stage image
+COPY --from=builder --chown=$SERVICE_NAME:$SERVICE_NAME /root/.local /home/$SERVICE_NAME/.local
+COPY --from=builder /usr/sbin/gosu /usr/sbin/gosu
+
+COPY entrypoint.sh /root/entrypoint.sh
+RUN chmod +x /root/entrypoint.sh
+
+# copy the content of the local src and config directory to the working directory
+COPY config .
+COPY src .
+
 EXPOSE 5005
 
 # command to run on container start
+ENTRYPOINT ["/root/entrypoint.sh"]
 CMD [ "python3", "./server.py" ]
 
+LABEL org.label-schema.build-date=$BUILD_DATE 
 LABEL org.opencontainers.image.authors="Stefan Allius <stefan.allius@t-online.de>"
 LABEL org.opencontainers.image.source https://github.com/s-allius/tsun-gen3-proxy
 LABEL org.opencontainers.image.description 'The "TSUN Gen3 Micro-Inverter" proxy enables a reliable connection between TSUN third generation inverters and an MQTT broker to integrate the inverter into typical home automations'
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"
+LABEL org.opencontainers.image.vendor="Stefan Allius>"

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+user="$(id -u)"
+echo "#############################################"
+echo "# start: '$SERVICE_NAME'"
+echo "# with UserID:$UID, GroupID:$GID"
+echo "#############################################"
+
+if [ "$user" = '0' ]; then
+	[ -d "/home/$SERVICE_NAME" ] && chown -R $SERVICE_NAME:$SERVICE_NAME /home/$SERVICE_NAME || true
+    exec gosu $SERVICE_NAME "$@"
+else
+    exec "$@"
+fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,19 +67,16 @@ services:
   tsun-proxy:
     container_name: tsun-proxy
     image: ghcr.io/s-allius/tsun-gen3-proxy:latest
-    build: 
-       context: https://github.com/s-allius/tsun-gen3-proxy.git#main:app
-       args:
-         - UID=1000
     restart: unless-stopped
     depends_on:
       - mqtt
     environment:
       - TZ=Europe/Brussels
-      - SERVICE_NAME=tsun-proxy
+      - UID=${UID:-1000}
+      - GID=${GID:-1000}
     dns:
-      - 8.8.8.8
-      - 4.4.4.4
+      - ${DNS1:-8.8.8.8}
+      - $(DNS2:-4.4.4.4}
     ports: 
       - 5005:5005
     volumes:


### PR DESCRIPTION
fixes #2: 
Now you can easily set the uid and gid of the proxy without having to recreate the container. Just set the uid and gid variables in your environment before starting the container. The proxy will adjust the ownership of all configuration and log files accordingly. 

