### PR TITLE
optimise versionstring handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Reading the version string from the image updates it even if the image is re-pulled without re-deployment
+  
 ## [0.10.1] - 2024-08-10
 
 - fix displaying the version string at startup and in HA [#153](https://github.com/s-allius/tsun-gen3-proxy/issues/153)

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -34,7 +34,6 @@ ARG GID
 ARG LOG_LVL
 ARG environment
 
-ENV VERSION=$VERSION
 ENV SERVICE_NAME=$SERVICE_NAME
 ENV UID=$UID
 ENV GID=$GID 
@@ -63,6 +62,7 @@ RUN python -m pip install --no-cache --no-index /root/wheels/* && \
 COPY --chmod=0700 entrypoint.sh /root/entrypoint.sh
 COPY config .
 COPY src .
+RUN echo ${VERSION} > /proxy-version.txt
 RUN date > /build-date.txt
 EXPOSE 5005 8127 10000
 

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -2,6 +2,8 @@
 set -e
 
 user="$(id -u)"
+export VERSION=$(cat /proxy-version.txt)
+
 echo "######################################################"
 echo "# prepare: '$SERVICE_NAME' Version:$VERSION"
 echo "# for running with UserID:$UID, GroupID:$GID"


### PR DESCRIPTION
- Reading the version string from the image updates it even if the image is re-pulled without re-deployment