### PR TITLE
get retention time from the add-on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- add-on: Configure the retention time for log files  [#536](https://github.com/s-allius/tsun-gen3-proxy/issues/536)
 - add-on: Erase multiple logfiles in one step [#534](https://github.com/s-allius/tsun-gen3-proxy/issues/534)
 - bug fix for file retention from @mime24 [#522](https://github.com/s-allius/tsun-gen3-proxy/issues/522)
 - use python 3.14 in github action

--- a/ha_addons/ha_addon/rootfs/run.sh
+++ b/ha_addons/ha_addon/rootfs/run.sh
@@ -47,6 +47,9 @@ else
     export MQTT_PASSWORD
 fi
 
+# get logging config paramters
+LOG_RETENTION=$(bashio::config "logging.retention_days" 2)
+bashio::log.green "run.sh: info: found log retention: $LOG_RETENTION days"
 
 
 
@@ -59,4 +62,4 @@ export VERSION=$(cat /proxy-version.txt)
 
 bashio::log.blue "run.sh: info: Start Proxyserver..."
 bashio::log.blue "-----------------------------------------------------------"
-python3 server.py --rel_urls --json_config=/data/options.json  --log_path=/homeassistant/tsun-proxy/logs/ --config_path=/homeassistant/tsun-proxy/ --log_backups=2
+python3 server.py --rel_urls --json_config=/data/options.json  --log_path=/homeassistant/tsun-proxy/logs/ --config_path=/homeassistant/tsun-proxy/ --log_backups=$LOG_RETENTION

--- a/ha_addons/templates/config.jinja
+++ b/ha_addons/templates/config.jinja
@@ -72,6 +72,8 @@ schema:
       pv1.type: str?
       pv2.manufacturer: str?
       pv2.type: str?
+  logging:
+    retention_days: int
 
   # optionale parameter
 
@@ -119,6 +121,8 @@ options:
       pv1.type: SF-M18/144550
       pv2.manufacturer: Shinefar
       pv2.type: SF-M18/144550
+  logging:
+    retention_days: 4
   tsun.enabled: true # set default
   solarman.enabled: true # set default
   inverters.allow_all: false # set default


### PR DESCRIPTION
The retention period for log files can be set via a command-line argument when the proxy starts.

This is not possible for Home Assistant users, as it must be configured in the startup code of the Home Assistant add-on.
Using bashio, the configuration should be searched for the relevant parameters, which are then passed to the proxy at startup. This allows the retention time to be easily set within the add-on.