### PR TITLE
S allius/issue555

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- add-on: fix and improve AppAmore profile [#555](https://github.com/s-allius/tsun-gen3-proxy/issues/555)
 - fix exception attribute error [#550](https://github.com/s-allius/tsun-gen3-proxy/issues/550)
 - add network tests to the web UI [#452](https://github.com/s-allius/tsun-gen3-proxy/issues/452)
 - Update ghcr.io/hassio-addons/base Docker tag to v20.1.0

--- a/ha_addons/ha_addon/Dockerfile
+++ b/ha_addons/ha_addon/Dockerfile
@@ -17,12 +17,8 @@ ARG BUILD_FROM="ghcr.io/hassio-addons/base:20.1.0"
 # hadolint ignore=DL3006
 FROM $BUILD_FROM AS base
 
-# Installiere Python, pip und virtuelle Umgebungstools
-RUN apk add --no-cache python3=3.12.13-r0 py3-pip=25.1.1-r1 && \
-    python -m venv /opt/venv && \
-    . /opt/venv/bin/activate
-
-ENV PATH="/opt/venv/bin:$PATH"
+# Installiere Python und pip
+RUN apk add --no-cache python3=3.12.13-r0 py3-pip=25.1.1-r1
 
 
 

--- a/ha_addons/ha_addon/rootfs/run.sh
+++ b/ha_addons/ha_addon/rootfs/run.sh
@@ -62,7 +62,8 @@ mkdir -p /homeassistant/tsun-proxy/logs
 cd /home/proxy || exit
 
 export VERSION=$(cat /proxy-version.txt)
+export SERVICE_NAME='TSUN-Proxy'
 
 bashio::log.blue "run.sh: info: Start Proxyserver..."
 bashio::log.blue "-----------------------------------------------------------"
-python3 server.py --rel_urls --json_config=/data/options.json  --log_path=/homeassistant/tsun-proxy/logs/ --config_path=/homeassistant/tsun-proxy/ --log_backups=$LOG_RETENTION
+/usr/bin/python3 /home/proxy/server.py --rel_urls --json_config=/data/options.json  --log_path=/homeassistant/tsun-proxy/logs/ --config_path=/homeassistant/tsun-proxy/ --log_backups=$LOG_RETENTION

--- a/ha_addons/templates/apparmor.jinja
+++ b/ha_addons/templates/apparmor.jinja
@@ -1,89 +1,110 @@
 #include <tunables/global>
 
+# ==========================================================
+#  AppArmor Profile for TSUN-Proxy Home Assistant Add-on.
+#  This profile manages a dual-stage execution:
+#  1. Main Profile: Handles S6-Overlay initialization and Bashio.
+#  2. Child Profile (myprogram): Restricted environment for the Python application.
+# ==========================================================
 profile {{slug}} flags=(attach_disconnected,mediate_deleted) {
 
+  # --- PROCESS CONTROL ---
+  # Allow S6-Overlay to manage services and handle lifecycle signals
   signal (send,receive) set=(kill,term),
+  capability kill,
+  # capability chown, setuid, setgid, dac_override, fowner,
 
-  # S6-Overlay Kernel-Rights
+  # --- BOOT & INIT (S6-Overlay) ---
   /init rix,
-  /dev/null rw,
-  /dev/urandom r,
-  /dev/tty rw,
-
   /bin/** ix,
   /command/** ix,
   /package/** rix,
-  
-  # Netzwerk-Zugriff für Bashio/Curl (Supervisor API Check)
-  network inet stream,
-  network inet dgram,
+  /run.sh rix,
 
-  /etc/** r,
-  /etc/services.d/** ix,
-  /etc/cont-init.d/** ix,
-  /etc/cont-finish.d/** ix,
-  
+  # --- SYSTEM RESOURCES ---
+  /dev/null rw,
+  /dev/urandom r,
+  /dev/tty rw,
+  /dev/console rw,
 
-  # Runtime & Verzeichnisse
-  /run/ w,
-  /run/** rwk,
-  /run/{s6,s6-rc*,service}/** ix,
-
-  # S6-Overlay Binaries
-  /usr/bin/[^p]* ix,   # Erlaubt fast alles, was nicht mit p anfängt (z.B. sed, grep)
-  /usr/bin/p[^y]* ix,  # Erlaubt Programme mit p, aber nicht py...
-  /usr/lib/bashio/** ix,
-  /data/** rw,
-  /tmp/** rwk,
-  
-  # Bibliotheken und der Linker (Essenziell für Bash und S6)
+  # --- LIBRARIES & LINKER ---
+  # 'mr' is essential to prevent Segmentation Faults during library loading
   /lib/** mr,
   /usr/lib/** mr,
-  
-  # Spezifisch für den dynamischen Linker
   /lib/ld-*.so* mr,
   /lib/*/ld-*.so* mr,
   /usr/lib/ld-*.so* mr,
 
-  # Entrypoint script run.sh
-  /run.sh rix,
+  # --- CONFIGURATION & RUNTIME ---
+  # Allow Bashio and S6 to access configs and runtime states
+  /etc/** r,
+  /etc/services.d/** ix,
+  /etc/cont-init.d/** ix,
+  /etc/cont-finish.d/** ix,
+  /usr/lib/bashio/** ix,
+  /data/** rw,
+  /tmp/** rwk,
+  
+  # Network access for Bashio (Supervisor API) and DNS
+  network inet stream,
+  network inet dgram,
+  
+  # --- RUNTIME DIRECTORIES (S6-RC) ---
+  /run/ w,
+  /run/** rwk,
+  /run/{s6,s6-rc*,service}/** ix,
+  
+  # --- EXECUTABLES ---
+  # Restricted /usr/bin access to avoid 'px' modifier conflicts with Python
+  /usr/bin/[^p]* ix,
+  /usr/bin/p[^y]* ix,
+  /usr/bin/env ix,
+
+  # --- TRANSITION TO PYTHON APPLICATION ---
+  # Transition to the child profile 'myprogram' when starting Python
   /proxy-version.txt r,
   /home/proxy/server.py r,
-
-  # Start new profile for service
   /usr/bin/python3* cx -> myprogram,
 
+  # ==========================================================
+  # CHILD PROFILE: The Python Application Environment
+  # ==========================================================
   profile myprogram flags=(attach_disconnected,mediate_deleted) {
-
-    # 1. System & Libs
+    
+    # 1. SYSTEM LIBRARIES & CORE
+    # Broad read access to /usr and /etc prevents start-up crashes (Segfaults)
     /usr/** r,
     /etc/** r,
-
     /usr/lib/** mr,
     /lib/** mr,
     /usr/local/lib/** mr,
+    /usr/bin/python3* ix,
 
-    # 2. App & HA Schnittstellen
+    # 2. APPLICATION DATA & PERSISTENCE
+    # Read-only for source code, Read-Write for data and logs
     /home/proxy/ r,
     /home/proxy/** r,
     /home/translations/** r,
     /homeassistant/tsun-proxy/** rw,
-    /data/** rw,             # Access to options.json and other files within your addon
+    /data/** rw,
 
-    # 3. System-Info & Kernel
+    # 3. KERNEL & HARDWARE ABSTRACTION
+    # Required for platform detection and network monitoring
     /proc/self/** r,
     /proc/cpuinfo r,
-    /sys/** r,               # Network-Test: Needed for Hw and platform detection
-    
-    # 4. Standard Hardware / Logs
+    /sys/** r,
     /dev/urandom r,
     /dev/tty rw,
+    /dev/console rw,
 
-    # 5. Netzwerk (aus der nameservice Abstraction unterstützt)
+    # 4. NETWORKING
+    # Allow the proxy to communicate with Inverters and MQTT Brokers
     network inet stream,
     network inet dgram,
 
-    # Signale vom Hauptprofil empfangen
+    # 5. INTER-PROCESS COMMUNICATION
+    # Receive termination signals from the main profile (S6 supervisor)
     signal (receive) peer=*{{slug}},
+
   }
 }

--- a/ha_addons/templates/apparmor.jinja
+++ b/ha_addons/templates/apparmor.jinja
@@ -1,52 +1,89 @@
 #include <tunables/global>
 
 profile {{slug}} flags=(attach_disconnected,mediate_deleted) {
-  #include <abstractions/base>
 
-  # Capabilities
-  file,
-  signal (send) set=(kill,term,int,hup,cont),
+  signal (send,receive) set=(kill,term),
 
-  # S6-Overlay
-  /init ix,
-  /bin/** ix,
-  /usr/bin/** ix,
-  /run/{s6,s6-rc*,service}/** ix,
-  /package/** ix,
-  /command/** ix,
-  /etc/services.d/** rwix,
-  /etc/cont-init.d/** rwix,
-  /etc/cont-finish.d/** rwix,
-  /run/{,**} rwk,
+  # S6-Overlay Kernel-Rights
+  /init rix,
+  /dev/null rw,
+  /dev/urandom r,
   /dev/tty rw,
 
-  # Bashio
-  /usr/lib/bashio/** ix,
-  /tmp/** rwk,
+  /bin/** ix,
+  /command/** ix,
+  /package/** rix,
+  
+  # Netzwerk-Zugriff für Bashio/Curl (Supervisor API Check)
+  network inet stream,
+  network inet dgram,
 
-  # Access to options.json and other files within your addon
+  /etc/** r,
+  /etc/services.d/** ix,
+  /etc/cont-init.d/** ix,
+  /etc/cont-finish.d/** ix,
+  
+
+  # Runtime & Verzeichnisse
+  /run/ w,
+  /run/** rwk,
+  /run/{s6,s6-rc*,service}/** ix,
+
+  # S6-Overlay Binaries
+  /usr/bin/[^p]* ix,   # Erlaubt fast alles, was nicht mit p anfängt (z.B. sed, grep)
+  /usr/bin/p[^y]* ix,  # Erlaubt Programme mit p, aber nicht py...
+  /usr/lib/bashio/** ix,
   /data/** rw,
+  /tmp/** rwk,
+  
+  # Bibliotheken und der Linker (Essenziell für Bash und S6)
+  /lib/** mr,
+  /usr/lib/** mr,
+  
+  # Spezifisch für den dynamischen Linker
+  /lib/ld-*.so* mr,
+  /lib/*/ld-*.so* mr,
+  /usr/lib/ld-*.so* mr,
+
+  # Entrypoint script run.sh
+  /run.sh rix,
+  /proxy-version.txt r,
+  /home/proxy/server.py r,
 
   # Start new profile for service
-  /usr/bin/myprogram cx -> myprogram,
+  /usr/bin/python3* cx -> myprogram,
 
   profile myprogram flags=(attach_disconnected,mediate_deleted) {
-    #include <abstractions/base>
 
-    # Receive signals from S6-Overlay
-    signal (receive) peer=*_{{slug}},
+    # 1. System & Libs
+    /usr/** r,
+    /etc/** r,
 
-    # Access to options.json and other files within your addon
-    /data/** rw,
+    /usr/lib/** mr,
+    /lib/** mr,
+    /usr/local/lib/** mr,
 
-    # Access to mapped volumes specified in config.json
-    /share/** rw,
+    # 2. App & HA Schnittstellen
+    /home/proxy/ r,
+    /home/proxy/** r,
+    /home/translations/** r,
+    /homeassistant/tsun-proxy/** rw,
+    /data/** rw,             # Access to options.json and other files within your addon
 
-    # Access required for service functionality
-    /usr/bin/myprogram r,
-    /bin/bash rix,
-    /bin/echo ix,
-    /etc/passwd r,
+    # 3. System-Info & Kernel
+    /proc/self/** r,
+    /proc/cpuinfo r,
+    /sys/** r,               # Network-Test: Needed for Hw and platform detection
+    
+    # 4. Standard Hardware / Logs
+    /dev/urandom r,
     /dev/tty rw,
+
+    # 5. Netzwerk (aus der nameservice Abstraction unterstützt)
+    network inet stream,
+    network inet dgram,
+
+    # Signale vom Hauptprofil empfangen
+    signal (receive) peer=*{{slug}},
   }
 }

--- a/ha_addons/templates/config.jinja
+++ b/ha_addons/templates/config.jinja
@@ -4,7 +4,6 @@ version: {% if version is defined and version|length %} {{version}} {% elif Buil
 image: {{image}}
 url: https://github.com/s-allius/tsun-gen3-proxy
 slug: {{slug}}
-advanced: {{advanced}}
 stage: {{stage}}
 init: false
 arch:

--- a/ha_addons/templates/debug_data.json
+++ b/ha_addons/templates/debug_data.json
@@ -4,7 +4,6 @@
     "description": "MQTT Proxy for TSUN Photovoltaic Inverters with Debug Logging",
     "image": "docker.io/sallius/tsun-gen3-addon",
     "slug": "tsun-proxy-debug",
-    "advanced": true,
     "stage": "experimental",
     "readme_descr": "This is a bleeding-edge version of the `TSUN Proxy`  Add-On with debuging enabled by default.\n\nThe versions may be based on different feature branches and therefore the range of functions may change.\n\nIt is intended to be used to simulate special situations/problems and should only be used in consultation with the maintainer.\n\nFor production please use the stable version `TSUN Proxy`. If you are interested in a bleeding edge version, we offer the `TSUN Proxy (dev)` version.",
     "readme_links": ""

--- a/ha_addons/templates/dev_data.json
+++ b/ha_addons/templates/dev_data.json
@@ -4,7 +4,6 @@
     "description": "MQTT Proxy for TSUN Photovoltaic Inverters",
     "image": "docker.io/sallius/tsun-gen3-addon",
     "slug": "tsun-proxy-dev",
-    "advanced": false,
     "stage": "experimental",
     "readme_descr": "This is a bleeding-edge version of the `TSUN Proxy`  Add-On.\n\nThe versions may be based on different feature branches and therefore the range of functions may change.\n\nIt is intended for testing new functions or testing new devices that are to be supported with the next release.\nFor production, please use the stable version 'TSUN Proxy'.",
     "readme_links": ""

--- a/ha_addons/templates/rc_data.json
+++ b/ha_addons/templates/rc_data.json
@@ -4,7 +4,6 @@
     "description": "MQTT Proxy for TSUN Photovoltaic Inverters",
     "image": "ghcr.io/s-allius/tsun-gen3-addon",
     "slug": "tsun-proxy-rc",
-    "advanced": true,
     "stage": "experimental",
     "readme_descr": "This is a release candidate of the `TSUN Proxy` Add-On.\n\nIt is intended for testing the next release.\nFor production, please use the stable version 'TSUN Proxy'.",
     "readme_links": ""

--- a/ha_addons/templates/rel_data.json
+++ b/ha_addons/templates/rel_data.json
@@ -4,7 +4,6 @@
     "description": "MQTT Proxy for TSUN Photovoltaic Inverters",
     "image": "ghcr.io/s-allius/tsun-gen3-addon",
     "slug": "tsun-proxy",
-    "advanced": false,
     "stage": "stable",
     "readme_descr": "Integrates TSUN inverters (e.g. TSOL MS800, MS2000, MS3000) and batteries (TSOL DC1000) into Home Assistant.\n\nIt is based on the [TSUN Proxy][tsunproxy] and enables a reliable connection between TSUN devices and an MQTT broker.\n\nWith the Add-on, you can easily retrieve real-time values such as power, current and daily energy and integrate the inverter into Home Assistant.\nThis works even without an internet connection.\n\nThe optional connection to the TSUN Cloud can be disabled!",
     "readme_links": "\n[tsunproxy]: https://github.com/s-allius/tsun-gen3-proxy\n"


### PR DESCRIPTION
Fix and improve the AppArmor Profile for TSUN-Proxy Home Assistant Add-on.

The profile manages a dual-stage execution:
 1. Main Profile: Handles S6-Overlay initialization and Bashio.
 2.  Child Profile (myprogram): Restricted environment for the Python application.

---

Additionally, this pull request includes:
- Removes the deprecated "advanced" value from the add-on configuration
- Removes the venv layer from the add-on, since we only have a single Python application in a Docker environment...
