### PR TITLE
Clean up CHANGELOG by removing duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update dependency coverage to v7.14.0
 - Update dependency python to v3.14.5
 
-### Changed
-
-- Update dependency coverage to v7.14.0
-- Update dependency python to v3.14.5
-
 ## [0.15.0] - 2026-05-10
 
 ### Added


### PR DESCRIPTION
Removed duplicate entries for coverage and python updates.