### PR TITLE
S allius/issue624

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MX3000D: the proxy only register 2 PV modules at Home Assistant
+- MX450: the proxy register more than 1 PV module at Home Assistant
 - HA App: replace deprecated bashio repository
 - Agentic workflows should not be vulnerable to path injection attacks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update dependency tzlocal to v5.4.4
 - Update dependency coverage to v7.14.3
 - Update dependency coverage to v7.14.2
 - Update dependency pytest to v9.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update dependency coverage to v7.14.3
 - Update dependency coverage to v7.14.2
 - Update dependency pytest to v9.1.1
 - Update actions/checkout action to v7

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ If you use a Pi-hole, you can also store the host entry in the Pi-hole.
 
 ## Features
 
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX450, MX-800 and MX1000
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX3000 (from version 0.16)
 - Supports TSUN GEN3 PLUS inverters: TSOL-MS2000, MS1800 and MS1600
-- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000 (from version 0.13)
+- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000
 - Supports TSUN GEN3 inverters: TSOL-MS3000, MS800, MS700, MS600, MS400, MS350 and MS300
 - `MQTT` support
 - `Home-Assistant` auto-discovery support
@@ -424,14 +426,19 @@ In the following table you will find an overview of which inverter model has bee
 A combination with a red question mark should work, but I have not checked it in detail.
 
 <table align="center">
-  <tr><th align="center">Micro Inverter Model</th><th align="center">Fw. 1.00.06</th><th align="center">Fw. 1.00.17</th><th align="center">Fw. 1.00.20</th><th align="center">Fw. 4.0.10</th><th align="center">Fw. 4.0.20</th></tr>
-  <tr><td>GEN3 micro inverters (single MPPT):<br>MS300, MS350, MS400<br>MS400-D</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">➖</td><td align="center">➖</td></tr>
-  <tr><td>GEN3 micro inverters (dual MPPT):<br>MS600, MS700, MS800<br>MS600-D, MS800-D</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">➖</td><td align="center">➖</td></tr>
-  <tr><td>GEN3 micro inverters (quad MPPT):<br>MS3000</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">➖</td><td align="center">➖</td></tr>
-  <tr><td>GEN3 PLUS micro inverters:<br>MS1600, MS1800, MS2000<br>MS2000-D, MS800</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
-  <tr><td>GEN3 PLUS storage systems:<br>DC1000</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><th align="center">Micro Inverter Model</th><th align="center">SNR Prfx</th><th align="center">Fw. 1.00.17</th><th align="center">Fw. 1.00.20</th><th align="center">Fw. 4.0.10</th><th align="center">Fw. 4.0.20</th></tr>
+  <tr><td>GEN3 PLUS micro inverters:<br>MX3000, MX1000, MX450</td><td align="center">Y00</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 PLUS micro inverters:<br>MS1600, MS1800, MS2000<br>MS2000-D, MS800</td><td align="center">Y17, Y47</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 PLUS storage systems:<br>DC1000</td><td align="center">410, Y00</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
   <tr><td>GEN3 PLUS smart meter:<br>TSOL-MG3-MS, DDZY422-D2</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td><td align="center">❓</td><td align="center">❓</td></tr>
 </<tr><td>TITAN micro inverters:<br>TSOL-MP3000, MP2250</td><td align="center">❓</td><td align="center">❓</td><td align="center">❓</td><td align="center">❓</td><td align="center">❓</td></tr>
+</table>
+
+<table align="center">
+  <tr><th align="center">Micro Inverter Model</th><th align="center">SNR Prfx</th><th align="center">Fw. 1.00.06</th><th align="center">Fw. 1.00.17</th><th align="center">Fw. 1.00.20</th></tr>
+  <tr><td>GEN3 micro inverters (single MPPT):<br>MS300, MS350, MS400<br>MS400-D</td><td align="center">R17</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 micro inverters (dual MPPT):<br>MS600, MS700, MS800<br>MS600-D, MS800-D</td><td align="center">R17, R47</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 micro inverters (quad MPPT):<br>MS3000</td><td align="center">R17</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td></tr>
 </table>
 
 ```txt

--- a/app/requirements-test.txt
+++ b/app/requirements-test.txt
@@ -6,4 +6,4 @@
     mock==5.2.0
     coverage==7.14.3
     jinja2-cli==1.0.1
-    tzlocal==5.4.3
+    tzlocal==5.4.4

--- a/app/requirements-test.txt
+++ b/app/requirements-test.txt
@@ -4,6 +4,6 @@
     pytest-cov==7.1.0
     python-dotenv==1.2.2
     mock==5.2.0
-    coverage==7.14.2
+    coverage==7.14.3
     jinja2-cli==1.0.1
     tzlocal==5.4.3

--- a/app/src/gen3plus/infos_g3p.py
+++ b/app/src/gen3plus/infos_g3p.py
@@ -229,7 +229,6 @@ class InfosG3P(Infos):
         self.set_db_def_value(Register.MANUFACTURER, 'TSUN')
         self.set_db_def_value(Register.EQUIPMENT_MODEL, 'TSOL-MSxx00')
         self.set_db_def_value(Register.CHIP_TYPE, 'IGEN TECH')
-        self.set_db_def_value(Register.NO_INPUTS, 2)
 
     def __hide_topic(self, row: dict) -> bool:
         if 'dep' in row:

--- a/app/src/gen3plus/solarman_v5.py
+++ b/app/src/gen3plus/solarman_v5.py
@@ -433,6 +433,7 @@ class SolarmanV5(SolarmanBase):
         super()._set_config_parms(inv, serial_no)
         snr = serial_no[:3]
         if '410' == snr:
+            self.db.set_db_def_value(Register.NO_INPUTS, 2)
             self.db.set_db_def_value(Register.EQUIPMENT_MODEL,
                                      'TSOL-DC1000')
         elif 'Y00' == snr:
@@ -638,15 +639,23 @@ class SolarmanV5(SolarmanBase):
         max_pow = db.get_db_value(Register.MAX_DESIGNED_POWER, 0)
         rated = db.get_db_value(Register.RATED_POWER, 0)
         if max_pow == 0:
-            logger.warning('Max designed power is zero, '
-                           'cannot determine model name!')
+            logging.debug('Max designed power is zero, '
+                          'cannot determine model name!')
             return
         snr_prefix = self.inv_serial[:3]
 
         # 1. Set default number of inputs based on max power
-        input_mapping = {3000: 6, 2000: 4, 1800: 4, 1600: 4}
+        input_mapping = {3300: 6, 3000: 6, 2700: 6, 2500: 6, 2400: 6,
+                         2250: 4, 2000: 4, 1800: 4, 1600: 4,
+                         500: 1, 450: 1, 400: 1, 350: 1, 300: 1}
         if max_pow in input_mapping:
+            logging.info('Setting number of inputs to '
+                         f'{input_mapping[max_pow]} ')
             db.set_db_def_value(Register.NO_INPUTS, input_mapping[max_pow])
+        else:
+            logging.warning(f'Unexpected max designed power: {max_pow}, '
+                            'defaulting number of inputs to 2.')
+            db.set_db_def_value(Register.NO_INPUTS, 2)
 
         # 2. Determine the model series (MX or MS)
         if snr_prefix == 'Y00':
@@ -668,7 +677,7 @@ class SolarmanV5(SolarmanBase):
         model = f'TSOL-{series}{max_pow}{extra}{suffix}'
 
         # 6. Log the result and save it to the database
-        logger.info(f'Model: {model}')
+        logging.info(f"Setting model to: '{model}'")
         db.set_db_def_value(Register.EQUIPMENT_MODEL, model)
 
     def __process_data(self, ftype, ts, sensor=0):
@@ -683,6 +692,9 @@ class SolarmanV5(SolarmanBase):
                 self.new_data[key] = True
 
         if inv_update:
+            logging.debug("SolarmannV5:__process_data calls"
+                          " __build_model_name")
+
             self.__build_model_name()
     '''
     Message handler methods
@@ -877,6 +889,8 @@ class SolarmanV5(SolarmanBase):
             inv_update = self.__parse_modbus_rsp(data, modbus_msg_len)
 
             if inv_update:
+                logging.debug("SolarmannV5:__modbus_command_rsp calls"
+                              " __build_model_name")
                 self.__build_model_name()
 
             # Handle inverter emulation setup

--- a/app/src/inverter_base.py
+++ b/app/src/inverter_base.py
@@ -168,6 +168,7 @@ class InverterBase(InverterIfc, Proxy):
                     or ('collector' in stream.new_data and
                         stream.new_data['collector'])
                     or self.mqtt.ha_restarts != self.__ha_restarts):
+                logging.info("Registering proxy entities with Home Assistant")
                 await self._register_proxy_stat_home_assistant()
                 await self.__register_home_assistant(stream)
                 self.__ha_restarts = self.mqtt.ha_restarts

--- a/app/tests/test_infos_g3p.py
+++ b/app/tests/test_infos_g3p.py
@@ -343,7 +343,7 @@ def test_build_ha_conf3():
 
         elif id == 'power_pv5_123':
             assert comp == 'sensor'
-            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv4_123", "val_tpl": "{{ (value_json['pv4']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV4", "sa": "Module PV4", "via_device": "inverter_123", "ids": ["input_pv4_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv5_123", "val_tpl": "{{ (value_json['pv5']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV5", "sa": "Module PV5", "via_device": "inverter_123", "ids": ["input_pv5_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
             tests +=1
 
         elif id == 'signal_123':

--- a/app/tests/test_infos_g3p.py
+++ b/app/tests/test_infos_g3p.py
@@ -109,7 +109,7 @@ def test_default_db():
     i = InfosG3P(client_mode=False)
     
     assert json.dumps(i.db) == json.dumps({
-        "inverter": {"Manufacturer": "TSUN", "Equipment_Model": "TSOL-MSxx00", "No_Inputs": 2}, 
+        "inverter": {"Manufacturer": "TSUN", "Equipment_Model": "TSOL-MSxx00"}, 
         "collector": {"Chip_Type": "IGEN TECH"},
         })
 
@@ -230,6 +230,7 @@ def test_build_ha_conf1():
     i = InfosG3P(client_mode=False)
     i.static_init()                # initialize counter
     i.set_db_def_value(Register.SENSOR_LIST, "02b0")
+    i.set_db_def_value(Register.NO_INPUTS, 2)
 
     tests = 0
     for d_json, comp, node_id, id in i.ha_confs(ha_prfx="tsun/", node_id="garagendach/", snr='123'):
@@ -305,6 +306,7 @@ def test_build_ha_conf3():
     i = InfosG3P(client_mode=True)
     i.static_init()                # initialize counter
     i.set_db_def_value(Register.SENSOR_LIST, "02b0")
+    i.set_db_def_value(Register.NO_INPUTS, 4)
 
     tests = 0
     for d_json, comp, node_id, id in i.ha_confs(ha_prfx="tsun/", node_id="garagendach/", snr='123'):
@@ -339,6 +341,11 @@ def test_build_ha_conf3():
             assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv4_123", "val_tpl": "{{ (value_json['pv4']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV4", "sa": "Module PV4", "via_device": "inverter_123", "ids": ["input_pv4_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
             tests +=1
 
+        elif id == 'power_pv5_123':
+            assert comp == 'sensor'
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv4_123", "val_tpl": "{{ (value_json['pv4']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV4", "sa": "Module PV4", "via_device": "inverter_123", "ids": ["input_pv4_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            tests +=1
+
         elif id == 'signal_123':
             assert comp == 'sensor'
             assert  d_json == json.dumps({})
@@ -346,7 +353,7 @@ def test_build_ha_conf3():
         elif id == 'inv_count_456':
             assert False
 
-    assert tests==5
+    assert tests==7
 
 def test_build_ha_conf4():
     i = InfosG3P(client_mode=True)

--- a/app/tests/test_solarman.py
+++ b/app/tests/test_solarman.py
@@ -1675,6 +1675,20 @@ async def test_build_modell_900_y00(my_loop, config_tsun_titan, inverter_ind_msg
     m.close()
 
 @pytest.mark.asyncio(loop_scope="module")
+async def test_build_modell_1000_410(my_loop, config_tsun_dcu1, dcu_data_ind_msg):
+    _ = config_tsun_dcu1
+    m = MemoryStream(dcu_data_ind_msg, (0,))
+    assert 0 == m.db.get_db_value(Register.MAX_DESIGNED_POWER, 0)
+    assert None == m.db.get_db_value(Register.RATED_POWER, None)
+    assert None == m.db.get_db_value(Register.INVERTER_TEMP, None)
+    m.read()         # read complete msg, and dispatch msg
+    assert 0 == m.db.get_db_value(Register.MAX_DESIGNED_POWER, 0)
+    assert 0 == m.db.get_db_value(Register.RATED_POWER, 0)
+    assert 2 == m.db.get_db_value(Register.NO_INPUTS, 0)
+    assert 'TSOL-DC1000' == m.db.get_db_value(Register.EQUIPMENT_MODEL, 0)
+    m.close()
+
+@pytest.mark.asyncio(loop_scope="module")
 async def test_build_logger_modell(my_loop, config_tsun_allow_all, device_ind_msg):
     _ = config_tsun_allow_all
     m = MemoryStream(device_ind_msg, (0,))
@@ -2971,7 +2985,7 @@ async def test_proxy_dcu_cmd(my_loop, config_tsun_dcu1, patch_open_connection, d
         assert l.db.stat['proxy']['AT_Command'] == 0
         assert l.db.stat['proxy']['AT_Command_Blocked'] == 0
         assert l.db.stat['proxy']['Modbus_Command'] == 0
-        assert 2 == l.db.get_db_value(Register.NO_INPUTS, 0)
+        assert 0 == l.db.get_db_value(Register.NO_INPUTS, 0)
 
         l.append_msg(dcu_command_rsp_msg)
         l.read() # read at resp

--- a/ha_addons/templates/README.jinja
+++ b/ha_addons/templates/README.jinja
@@ -4,8 +4,10 @@
 
 ## Features
 
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX450, MX-800 and MX1000
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX3000
 - Supports TSUN GEN3 PLUS inverters: TSOL-MS2000, MS1800 and MS1600
-- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000 (from version 0.13)
+- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000
 - Supports TSUN GEN3 inverters: TSOL-MS3000, MS800, MS700, MS600, MS400, MS350 and MS300
 - `Home-Assistant` auto-discovery support
 - `MODBUS` support via MQTT topics

--- a/ha_addons/templates/README.jinja
+++ b/ha_addons/templates/README.jinja
@@ -4,11 +4,17 @@
 
 ## Features
 
-- Supports TSUN GEN3 PLUS inverters: TSOL-MX450, MX-800 and MX1000
-- Supports TSUN GEN3 PLUS inverters: TSOL-MX3000
-- Supports TSUN GEN3 PLUS inverters: TSOL-MS2000, MS1800 and MS1600
-- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000
-- Supports TSUN GEN3 inverters: TSOL-MS3000, MS800, MS700, MS600, MS400, MS350 and MS300
+- Supports TSUN MX Series:
+  - Microinverter 1-in-1: TSOL-MX500, MX450 and MX400
+  - Microinverter 2-in-1: TSOL-MX1000, MX900 and MX800
+  - Microinverter 4-in-1: TSOL-MX2250
+  - Microinverter 6-in-1: TSOL-MX3300, MX3000, MX2700, MX2500 and MX2400
+- Supports TSUN MS Series:
+  - Microinverter 1-in-1: TSOL-MS400, MS350 and MS300
+  - Microinverter 2-in-1: TSOL-MS800, MS700 and MS600
+  - Microinverter 4-in-1: TSOL-MS2000, MS1800 and MS1600
+- Supports TSUN Batteries:
+  - DCU: TSOL-DC1000
 - `Home-Assistant` auto-discovery support
 - `MODBUS` support via MQTT topics
 - `AT-Command` support via MQTT topics (GEN3PLUS only)


### PR DESCRIPTION
Ensure that the PV modules are only registered one time at Home Assistant. 

Especially  inverters with one or more than 2 inputs, are often registered with 2 PV modules, which is wrong.