### PR TITLE
S allius/issue624-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MX3000D: the proxy only register 2 PV modules at Home Assistant
+- MX450: the proxy register more than 1 PV module at Home Assistant
 - HA App: replace deprecated bashio repository
 - Agentic workflows should not be vulnerable to path injection attacks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update dependency tzlocal to v5.4.4
 - Update dependency coverage to v7.14.3
 - Update dependency coverage to v7.14.2
 - Update dependency pytest to v9.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update dependency coverage to v7.14.3
 - Update dependency coverage to v7.14.2
 - Update dependency pytest to v9.1.1
 - Update actions/checkout action to v7

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ If you use a Pi-hole, you can also store the host entry in the Pi-hole.
 
 ## Features
 
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX450, MX-800 and MX1000
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX3000 (from version 0.16)
 - Supports TSUN GEN3 PLUS inverters: TSOL-MS2000, MS1800 and MS1600
-- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000 (from version 0.13)
+- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000
 - Supports TSUN GEN3 inverters: TSOL-MS3000, MS800, MS700, MS600, MS400, MS350 and MS300
 - `MQTT` support
 - `Home-Assistant` auto-discovery support
@@ -424,14 +426,19 @@ In the following table you will find an overview of which inverter model has bee
 A combination with a red question mark should work, but I have not checked it in detail.
 
 <table align="center">
-  <tr><th align="center">Micro Inverter Model</th><th align="center">Fw. 1.00.06</th><th align="center">Fw. 1.00.17</th><th align="center">Fw. 1.00.20</th><th align="center">Fw. 4.0.10</th><th align="center">Fw. 4.0.20</th></tr>
-  <tr><td>GEN3 micro inverters (single MPPT):<br>MS300, MS350, MS400<br>MS400-D</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">➖</td><td align="center">➖</td></tr>
-  <tr><td>GEN3 micro inverters (dual MPPT):<br>MS600, MS700, MS800<br>MS600-D, MS800-D</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">➖</td><td align="center">➖</td></tr>
-  <tr><td>GEN3 micro inverters (quad MPPT):<br>MS3000</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">➖</td><td align="center">➖</td></tr>
-  <tr><td>GEN3 PLUS micro inverters:<br>MS1600, MS1800, MS2000<br>MS2000-D, MS800</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
-  <tr><td>GEN3 PLUS storage systems:<br>DC1000</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><th align="center">Micro Inverter Model</th><th align="center">SNR Prfx</th><th align="center">Fw. 1.00.17</th><th align="center">Fw. 1.00.20</th><th align="center">Fw. 4.0.10</th><th align="center">Fw. 4.0.20</th></tr>
+  <tr><td>GEN3 PLUS micro inverters:<br>MX3000, MX1000, MX450</td><td align="center">Y00</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 PLUS micro inverters:<br>MS1600, MS1800, MS2000<br>MS2000-D, MS800</td><td align="center">Y17, Y47</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 PLUS storage systems:<br>DC1000</td><td align="center">410, Y00</td><td align="center">➖</td><td align="center">➖</td><td align="center">✔️</td><td align="center">✔️</td></tr>
   <tr><td>GEN3 PLUS smart meter:<br>TSOL-MG3-MS, DDZY422-D2</td><td align="center">➖</td><td align="center">➖</td><td align="center">➖</td><td align="center">❓</td><td align="center">❓</td></tr>
 </<tr><td>TITAN micro inverters:<br>TSOL-MP3000, MP2250</td><td align="center">❓</td><td align="center">❓</td><td align="center">❓</td><td align="center">❓</td><td align="center">❓</td></tr>
+</table>
+
+<table align="center">
+  <tr><th align="center">Micro Inverter Model</th><th align="center">SNR Prfx</th><th align="center">Fw. 1.00.06</th><th align="center">Fw. 1.00.17</th><th align="center">Fw. 1.00.20</th></tr>
+  <tr><td>GEN3 micro inverters (single MPPT):<br>MS300, MS350, MS400<br>MS400-D</td><td align="center">R17</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 micro inverters (dual MPPT):<br>MS600, MS700, MS800<br>MS600-D, MS800-D</td><td align="center">R17, R47</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td></tr>
+  <tr><td>GEN3 micro inverters (quad MPPT):<br>MS3000</td><td align="center">R17</td><td align="center">✔️</td><td align="center">✔️</td><td align="center">✔️</td></tr>
 </table>
 
 ```txt

--- a/app/requirements-test.txt
+++ b/app/requirements-test.txt
@@ -6,4 +6,4 @@
     mock==5.2.0
     coverage==7.14.3
     jinja2-cli==1.0.1
-    tzlocal==5.4.3
+    tzlocal==5.4.4

--- a/app/requirements-test.txt
+++ b/app/requirements-test.txt
@@ -4,6 +4,6 @@
     pytest-cov==7.1.0
     python-dotenv==1.2.2
     mock==5.2.0
-    coverage==7.14.2
+    coverage==7.14.3
     jinja2-cli==1.0.1
     tzlocal==5.4.3

--- a/app/src/gen3plus/infos_g3p.py
+++ b/app/src/gen3plus/infos_g3p.py
@@ -156,37 +156,37 @@ class RegisterMap:
         # entities with home assistant, the offset is behind the length
         # of the message, so they are not part of the message, but they
         # are needed for the entities to be created
-        0x420100e0: {'reg': Register.PV1_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100e2: {'reg': Register.PV1_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x420100e4: {'reg': Register.PV1_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100e6: {'reg': Register.PV2_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100e8: {'reg': Register.PV2_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x420100ea: {'reg': Register.PV2_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100ec: {'reg': Register.PV3_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100ee: {'reg': Register.PV3_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x420100f0: {'reg': Register.PV3_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100f2: {'reg': Register.PV4_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100f4: {'reg': Register.PV4_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x420100f6: {'reg': Register.PV4_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100f8: {'reg': Register.PV5_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x420100fa: {'reg': Register.PV5_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x420100fe: {'reg': Register.PV5_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x42010100: {'reg': Register.PV6_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
-        0x42010102: {'reg': Register.PV6_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x42010104: {'reg': Register.PV6_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0e0: {'reg': Register.PV1_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0e2: {'reg': Register.PV1_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f0e4: {'reg': Register.PV1_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0e6: {'reg': Register.PV2_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0e8: {'reg': Register.PV2_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f0ea: {'reg': Register.PV2_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0ec: {'reg': Register.PV3_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0ee: {'reg': Register.PV3_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f0f0: {'reg': Register.PV3_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0f2: {'reg': Register.PV4_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0f4: {'reg': Register.PV4_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f0f6: {'reg': Register.PV4_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0f8: {'reg': Register.PV5_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f0fa: {'reg': Register.PV5_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f0fe: {'reg': Register.PV5_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f100: {'reg': Register.PV6_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x4201f102: {'reg': Register.PV6_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f104: {'reg': Register.PV6_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
 
-        0x42010106: {'reg': Register.PV1_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x42010108: {'reg': Register.PV1_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
-        0x4201010c: {'reg': Register.PV2_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x4201010e: {'reg': Register.PV2_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
-        0x42010112: {'reg': Register.PV3_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x42010114: {'reg': Register.PV3_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
-        0x42010118: {'reg': Register.PV4_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x4201011a: {'reg': Register.PV4_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
-        0x4201011e: {'reg': Register.PV5_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x42010120: {'reg': Register.PV5_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
-        0x42010124: {'reg': Register.PV6_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
-        0x42010126: {'reg': Register.PV6_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201f106: {'reg': Register.PV1_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f108: {'reg': Register.PV1_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201f10c: {'reg': Register.PV2_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f10e: {'reg': Register.PV2_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201f112: {'reg': Register.PV3_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f114: {'reg': Register.PV3_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201f118: {'reg': Register.PV4_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f11a: {'reg': Register.PV4_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201f11e: {'reg': Register.PV5_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f120: {'reg': Register.PV5_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201f124: {'reg': Register.PV6_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201f126: {'reg': Register.PV6_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
     }
     map_3026 = {
         'len': 0x7a,

--- a/app/src/gen3plus/infos_g3p.py
+++ b/app/src/gen3plus/infos_g3p.py
@@ -1,5 +1,6 @@
 
-from typing import Generator
+import logging
+from collections.abc import Generator
 from itertools import chain
 
 from infos import Infos, Register, ProxyMode, Fmt
@@ -150,6 +151,42 @@ class RegisterMap:
         0x4201000c: {'reg': Register.SENSOR_LIST,          'fmt': '<H', 'func': Fmt.hex4},   # noqa: E501
         0x4201001c: {'reg': Register.POWER_ON_TIME,        'fmt': '<H', 'ratio':    1, 'dep': ProxyMode.SERVER},  # noqa: E501
         0x42010020: {'reg': Register.SERIAL_NUMBER,        'fmt': '!16s'},               # noqa: E501
+
+        # fixme, the following registers are needed for registering the
+        # entities with home assistant, the offset is behind the length
+        # of the message, so they are not part of the message, but they
+        # are needed for the entities to be created
+        0x420100e0: {'reg': Register.PV1_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100e2: {'reg': Register.PV1_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x420100e4: {'reg': Register.PV1_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100e6: {'reg': Register.PV2_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100e8: {'reg': Register.PV2_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x420100ea: {'reg': Register.PV2_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100ec: {'reg': Register.PV3_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100ee: {'reg': Register.PV3_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x420100f0: {'reg': Register.PV3_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100f2: {'reg': Register.PV4_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100f4: {'reg': Register.PV4_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x420100f6: {'reg': Register.PV4_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100f8: {'reg': Register.PV5_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x420100fa: {'reg': Register.PV5_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x420100fe: {'reg': Register.PV5_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x42010100: {'reg': Register.PV6_VOLTAGE,          'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+        0x42010102: {'reg': Register.PV6_CURRENT,          'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x42010104: {'reg': Register.PV6_POWER,            'fmt': '!H', 'ratio':  0.1},  # noqa: E501
+
+        0x42010106: {'reg': Register.PV1_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x42010108: {'reg': Register.PV1_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201010c: {'reg': Register.PV2_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201010e: {'reg': Register.PV2_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x42010112: {'reg': Register.PV3_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x42010114: {'reg': Register.PV3_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x42010118: {'reg': Register.PV4_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x4201011a: {'reg': Register.PV4_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x4201011e: {'reg': Register.PV5_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x42010120: {'reg': Register.PV5_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
+        0x42010124: {'reg': Register.PV6_DAILY_GENERATION, 'fmt': '!H', 'ratio': 0.01},  # noqa: E501
+        0x42010126: {'reg': Register.PV6_TOTAL_GENERATION, 'fmt': '!L', 'ratio': 0.01},  # noqa: E501
     }
     map_3026 = {
         'len': 0x7a,
@@ -290,6 +327,8 @@ class InfosG3P(Infos):
                 continue
             info_id = row['reg']
             result = Fmt.get_value(buf, addr, row)
+            if result is None:
+                continue
             yield from self.__update_val(node_id, "GEN3PLUS", info_id, result)
         yield from self.calc(sensor, node_id)
 
@@ -320,22 +359,26 @@ class InfosG3P(Infos):
     def build(self, msg_type: int, rcv_ftype: int, sensor: int = 0):
         reg_map = RegisterSel.get(sensor)
         buf = bytearray(reg_map['len'])
-        for idx, row in reg_map.items():
-            if 'calc' == idx or 'len' == idx:
-                continue
-            addr = idx & 0xffff
-            ftype = (idx >> 16) & 0xff
-            mtype = (idx >> 24) & 0xff
-            if ftype != rcv_ftype or mtype != msg_type:
-                continue
-            if not isinstance(row, dict):
-                continue
-            if 'const' in row:
-                val = row['const']
-            else:
-                info_id = row['reg']
-                val = self.get_db_value(info_id)
-            if not val:
-                continue
-            Fmt.set_value(buf, addr, row, val)
+        try:
+            for idx, row in reg_map.items():
+                if 'calc' == idx or 'len' == idx:
+                    continue
+                addr = idx & 0xffff
+                ftype = (idx >> 16) & 0xff
+                mtype = (idx >> 24) & 0xff
+                if ftype != rcv_ftype or mtype != msg_type:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if 'const' in row:
+                    val = row['const']
+                else:
+                    info_id = row['reg']
+                    val = self.get_db_value(info_id)
+                if not val:
+                    continue
+                Fmt.set_value(buf, addr, row, val)
+
+        except Exception as e:
+            self.tracer.log(logging.ERROR, f'[{sensor}] build: {e}')
         return buf

--- a/app/src/gen3plus/infos_g3p.py
+++ b/app/src/gen3plus/infos_g3p.py
@@ -229,7 +229,6 @@ class InfosG3P(Infos):
         self.set_db_def_value(Register.MANUFACTURER, 'TSUN')
         self.set_db_def_value(Register.EQUIPMENT_MODEL, 'TSOL-MSxx00')
         self.set_db_def_value(Register.CHIP_TYPE, 'IGEN TECH')
-        self.set_db_def_value(Register.NO_INPUTS, 2)
 
     def __hide_topic(self, row: dict) -> bool:
         if 'dep' in row:

--- a/app/src/gen3plus/solarman_v5.py
+++ b/app/src/gen3plus/solarman_v5.py
@@ -433,6 +433,7 @@ class SolarmanV5(SolarmanBase):
         super()._set_config_parms(inv, serial_no)
         snr = serial_no[:3]
         if '410' == snr:
+            self.db.set_db_def_value(Register.NO_INPUTS, 2)
             self.db.set_db_def_value(Register.EQUIPMENT_MODEL,
                                      'TSOL-DC1000')
         elif 'Y00' == snr:
@@ -638,15 +639,23 @@ class SolarmanV5(SolarmanBase):
         max_pow = db.get_db_value(Register.MAX_DESIGNED_POWER, 0)
         rated = db.get_db_value(Register.RATED_POWER, 0)
         if max_pow == 0:
-            logger.warning('Max designed power is zero, '
-                           'cannot determine model name!')
+            logging.debug('Max designed power is zero, '
+                          'cannot determine model name!')
             return
         snr_prefix = self.inv_serial[:3]
 
         # 1. Set default number of inputs based on max power
-        input_mapping = {3000: 6, 2000: 4, 1800: 4, 1600: 4}
+        input_mapping = {3300: 6, 3000: 6, 2700: 6, 2500: 6, 2400: 6,
+                         2250: 4, 2000: 4, 1800: 4, 1600: 4,
+                         500: 1, 450: 1, 400: 1, 350: 1, 300: 1}
         if max_pow in input_mapping:
+            logging.info('Setting number of inputs to '
+                         f'{input_mapping[max_pow]} ')
             db.set_db_def_value(Register.NO_INPUTS, input_mapping[max_pow])
+        else:
+            logging.warning(f'Unexpected max designed power: {max_pow}, '
+                            'defaulting number of inputs to 2.')
+            db.set_db_def_value(Register.NO_INPUTS, 2)
 
         # 2. Determine the model series (MX or MS)
         if snr_prefix == 'Y00':
@@ -668,7 +677,7 @@ class SolarmanV5(SolarmanBase):
         model = f'TSOL-{series}{max_pow}{extra}{suffix}'
 
         # 6. Log the result and save it to the database
-        logger.info(f'Model: {model}')
+        logging.info(f"Setting model to: '{model}'")
         db.set_db_def_value(Register.EQUIPMENT_MODEL, model)
 
     def __process_data(self, ftype, ts, sensor=0):
@@ -683,6 +692,9 @@ class SolarmanV5(SolarmanBase):
                 self.new_data[key] = True
 
         if inv_update:
+            logging.debug("SolarmannV5:__process_data calls"
+                          " __build_model_name")
+
             self.__build_model_name()
     '''
     Message handler methods
@@ -877,6 +889,8 @@ class SolarmanV5(SolarmanBase):
             inv_update = self.__parse_modbus_rsp(data, modbus_msg_len)
 
             if inv_update:
+                logging.debug("SolarmannV5:__modbus_command_rsp calls"
+                              " __build_model_name")
                 self.__build_model_name()
 
             # Handle inverter emulation setup

--- a/app/src/infos.py
+++ b/app/src/infos.py
@@ -273,7 +273,7 @@ class Fmt:
 
     @staticmethod
     def set_value(buf: bytearray, idx: int, row: dict, val):
-        '''Get a value from buf and interpret as in row defined'''
+        '''Build and set a value in buf as in row defined'''
         fmt = row['fmt']
         if 'offset' in row:
             val = val - row['offset']

--- a/app/src/inverter_base.py
+++ b/app/src/inverter_base.py
@@ -168,6 +168,7 @@ class InverterBase(InverterIfc, Proxy):
                     or ('collector' in stream.new_data and
                         stream.new_data['collector'])
                     or self.mqtt.ha_restarts != self.__ha_restarts):
+                logging.info("Registering proxy entities with Home Assistant")
                 await self._register_proxy_stat_home_assistant()
                 await self.__register_home_assistant(stream)
                 self.__ha_restarts = self.mqtt.ha_restarts

--- a/app/src/web/network_tests.py
+++ b/app/src/web/network_tests.py
@@ -136,7 +136,7 @@ async def test_script() -> None:
     else:
         host = config_tsun['host']
         ip = await resolve(host)
-        logger.info(f"DNS test: '{host}' {_("resolved to")}"
+        logger.info(f"DNS test: '{host}' {_('resolved to')}"
                     f" {ip} ==> Ok")
     # forwarding for port 10000 enabled?
     #  then check DNS resolution for Solarman cloud
@@ -146,7 +146,7 @@ async def test_script() -> None:
     else:
         host = config_solarman['host']
         ip = await resolve(host)
-        logger.info(f"DNS test: '{host}' {_("resolved to")}"
+        logger.info(f"DNS test: '{host}' {_('resolved to')}"
                     f" {ip} ==> Ok")
     # determine host ip of the proxy
     host_ip = await get_best_guess_host_ip()

--- a/app/tests/test_infos_g3p.py
+++ b/app/tests/test_infos_g3p.py
@@ -105,6 +105,13 @@ def batterie_data2():  # 0x4210 ftype: 0x01
     msg += b'\x0c\x89\x0c\x89\x0c\x88\x00\x0f\x00\x0f\x00\x0f\x00\x0e'
     return msg
 
+@pytest.fixture
+def inverter_1097_data():  # 0x4210 ftype: 0x01
+    msg  = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x97\x10\xc7\xde'
+    msg += b'\x2d\x32\x28\x00\x00\x00\x84\x17\x79\x35\x01\x00\x4c\x12\x00\x00'
+    msg += b'\x34\x31\x30\x31\x32\x34\x30\x37\x30\x31\x34\x39\x30\x33\x31\x34'
+    return msg
+
 def test_default_db():
     i = InfosG3P(client_mode=False)
     
@@ -209,8 +216,7 @@ def test_parse_4210_3026_incomplete(batterie_data2: bytes):
                       "pv2": {"Voltage": 33.72, "Current": 0.0, "MPPT-Status": 0}, 
                       "batt": {"Total_Charging": 20.8, "Voltage": 51.34, "Current": 7.66, "SOC": 10.0, "Power": 393.2644, 'Batt_State': 2},
                       "cell": {"Volt1": 3.21, "Volt2": 3.21, "Volt3": 3.21, "Volt4": 3.21, "Volt5": 3.21, "Volt6": 3.21, "Volt7": 3.21, "Volt8": 3.21, "Volt9": 3.21, "Volt10": 3.21, "Volt11": 3.21, "Volt12": 3.21, "Volt13": 3.21, "Volt14": 3.21, "Volt15": 3.21, "Volt16": 3.21, "Temp_1": 15, "Temp_2": 15,  "Temp_3": 15}, 
-                      "out": {"Voltage": 0.14, "Current": None, "Out_Status": None, "Power": None, "Suppl_State": None},
-                      "Controller_Temp": None, "Batterie_Alarm": None, "Hardware_Version": None, "Software_Version": None, 
+                      "out": {"Voltage": 0.14, "Power": None, "Suppl_State": None},
                       "PV_Power": 37.9232},
          })
 
@@ -225,6 +231,22 @@ def test_build_4210(inverter_data: bytes):
     for i in range(11, 31):
         build_msg[i] = inverter_data[i]
     assert inverter_data == build_msg    
+
+def test_build_4210_1097(inverter_1097_data: bytes):
+    i = InfosG3P(client_mode=False)
+    i.db.clear()
+    
+    for key, update in i.parse (inverter_1097_data, 0x42, 1, 0x1097):
+        pass  #  side effect is calling generator i.parse()
+
+    # set additional value which is not defined al part of 4210 message in the
+    # RegisterMap for 0x1097, this will throw an exception which is catched and logged in the build() method
+    i.set_db_def_value(Register.PV1_POWER, 6)
+
+    build_msg = i.build(0x42, 1, 0x1097)
+    for i in range(11, 31):
+        build_msg[i] = inverter_1097_data[i]
+    assert inverter_1097_data == build_msg    
 
 def test_build_ha_conf1():
     i = InfosG3P(client_mode=False)
@@ -420,23 +442,40 @@ def test_build_ha_conf6():
     i = InfosG3P(client_mode=True)
     i.static_init()                # initialize counter
     i.set_db_def_value(Register.SENSOR_LIST, "1097")
+    i.set_db_def_value(Register.NO_INPUTS, 6)
 
     tests = 0
     for d_json, comp, node_id, id in i.ha_confs(ha_prfx="tsun/", node_id="garagendach/", snr='123'):
 
         if id == 'out_power_123':
             assert comp == 'sensor'
-            assert  d_json == json.dumps({"name": "Supply Power", "stat_t": "tsun/garagendach/batterie", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "out_power_123", "val_tpl": "{{ (value_json['out']['Power'] | int)}}", "unit_of_meas": "W", "dev": {"name": "Batterie", "sa": "Batterie", "via_device": "controller_123", "mdl": "TSOL-MSxx00", "mf": "TSUN", "ids": ["batterie_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            assert  d_json == json.dumps({"name": "Supply Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "out_power_123", "val_tpl": "{{ (value_json['out']['Power'] | int)}}", "unit_of_meas": "W", "dev": {"name": "Batterie", "sa": "Batterie", "via_device": "controller_123", "mdl": "TSOL-MSxx00", "mf": "TSUN", "ids": ["inverter_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
             tests +=1
         elif id == 'daily_gen_123':
             assert False
-        elif id == 'volt_pv1_123':
+        elif id == 'power_pv1_123':
             assert comp == 'sensor'
-            assert  d_json == json.dumps({"name": "Voltage", "stat_t": "tsun/garagendach/batterie", "dev_cla": "voltage", "stat_cla": "measurement", "uniq_id": "volt_pv1_123", "val_tpl": "{{ (value_json['pv1']['Voltage'] | float)}}", "unit_of_meas": "V", "ic": "mdi:gauge", "ent_cat": "diagnostic", "dev": {"name": "Module PV1", "sa": "Module PV1", "via_device": "batterie_123", "ids": ["bat_inp_pv1_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv1_123", "val_tpl": "{{ (value_json['pv1']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV1", "sa": "Module PV1", "via_device": "inverter_123", "ids": ["input_pv1_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
             tests +=1
-        elif id == 'volt_pv2_123':
+
+        elif id == 'power_pv2_123':
             assert comp == 'sensor'
-            assert  d_json == json.dumps({"name": "Voltage", "stat_t": "tsun/garagendach/batterie", "dev_cla": "voltage", "stat_cla": "measurement", "uniq_id": "volt_pv2_123", "val_tpl": "{{ (value_json['pv2']['Voltage'] | float)}}", "unit_of_meas": "V", "ic": "mdi:gauge", "ent_cat": "diagnostic", "dev": {"name": "Module PV2", "sa": "Module PV2", "via_device": "batterie_123", "ids": ["bat_inp_pv2_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv2_123", "val_tpl": "{{ (value_json['pv2']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV2", "sa": "Module PV2", "via_device": "inverter_123", "ids": ["input_pv2_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            tests +=1
+
+        elif id == 'power_pv3_123':
+            assert comp == 'sensor'
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv3_123", "val_tpl": "{{ (value_json['pv3']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV3", "sa": "Module PV3", "via_device": "inverter_123", "ids": ["input_pv3_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            tests +=1
+
+        elif id == 'power_pv4_123':
+            assert comp == 'sensor'
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv4_123", "val_tpl": "{{ (value_json['pv4']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV4", "sa": "Module PV4", "via_device": "inverter_123", "ids": ["input_pv4_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            tests +=1
+
+        elif id == 'power_pv6_123':
+            assert comp == 'sensor'
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv6_123", "val_tpl": "{{ (value_json['pv6']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV6", "sa": "Module PV6", "via_device": "inverter_123", "ids": ["input_pv6_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
             tests +=1
         elif id == 'signal_123':
             assert comp == 'sensor'
@@ -447,7 +486,7 @@ def test_build_ha_conf6():
         else:
             print('id: ' + id)
 
-    assert tests==1
+    assert tests==6
 
 def test_exception_and_calc(inverter_data: bytes):
 

--- a/app/tests/test_infos_g3p.py
+++ b/app/tests/test_infos_g3p.py
@@ -343,7 +343,7 @@ def test_build_ha_conf3():
 
         elif id == 'power_pv5_123':
             assert comp == 'sensor'
-            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv4_123", "val_tpl": "{{ (value_json['pv4']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV4", "sa": "Module PV4", "via_device": "inverter_123", "ids": ["input_pv4_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv5_123", "val_tpl": "{{ (value_json['pv5']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV5", "sa": "Module PV5", "via_device": "inverter_123", "ids": ["input_pv5_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
             tests +=1
 
         elif id == 'signal_123':

--- a/app/tests/test_infos_g3p.py
+++ b/app/tests/test_infos_g3p.py
@@ -109,7 +109,7 @@ def test_default_db():
     i = InfosG3P(client_mode=False)
     
     assert json.dumps(i.db) == json.dumps({
-        "inverter": {"Manufacturer": "TSUN", "Equipment_Model": "TSOL-MSxx00", "No_Inputs": 2}, 
+        "inverter": {"Manufacturer": "TSUN", "Equipment_Model": "TSOL-MSxx00"}, 
         "collector": {"Chip_Type": "IGEN TECH"},
         })
 
@@ -230,6 +230,7 @@ def test_build_ha_conf1():
     i = InfosG3P(client_mode=False)
     i.static_init()                # initialize counter
     i.set_db_def_value(Register.SENSOR_LIST, "02b0")
+    i.set_db_def_value(Register.NO_INPUTS, 2)
 
     tests = 0
     for d_json, comp, node_id, id in i.ha_confs(ha_prfx="tsun/", node_id="garagendach/", snr='123'):
@@ -305,6 +306,7 @@ def test_build_ha_conf3():
     i = InfosG3P(client_mode=True)
     i.static_init()                # initialize counter
     i.set_db_def_value(Register.SENSOR_LIST, "02b0")
+    i.set_db_def_value(Register.NO_INPUTS, 4)
 
     tests = 0
     for d_json, comp, node_id, id in i.ha_confs(ha_prfx="tsun/", node_id="garagendach/", snr='123'):
@@ -339,6 +341,11 @@ def test_build_ha_conf3():
             assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv4_123", "val_tpl": "{{ (value_json['pv4']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV4", "sa": "Module PV4", "via_device": "inverter_123", "ids": ["input_pv4_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
             tests +=1
 
+        elif id == 'power_pv5_123':
+            assert comp == 'sensor'
+            assert  d_json == json.dumps({"name": "Power", "stat_t": "tsun/garagendach/input", "dev_cla": "power", "stat_cla": "measurement", "uniq_id": "power_pv4_123", "val_tpl": "{{ (value_json['pv4']['Power'] | float)}}", "unit_of_meas": "W", "dev": {"name": "Module PV4", "sa": "Module PV4", "via_device": "inverter_123", "ids": ["input_pv4_123"]}, "o": {"name": "proxy", "sw": "unknown"}})
+            tests +=1
+
         elif id == 'signal_123':
             assert comp == 'sensor'
             assert  d_json == json.dumps({})
@@ -346,7 +353,7 @@ def test_build_ha_conf3():
         elif id == 'inv_count_456':
             assert False
 
-    assert tests==5
+    assert tests==7
 
 def test_build_ha_conf4():
     i = InfosG3P(client_mode=True)

--- a/app/tests/test_solarman.py
+++ b/app/tests/test_solarman.py
@@ -1675,6 +1675,20 @@ async def test_build_modell_900_y00(my_loop, config_tsun_titan, inverter_ind_msg
     m.close()
 
 @pytest.mark.asyncio(loop_scope="module")
+async def test_build_modell_1000_410(my_loop, config_tsun_dcu1, dcu_data_ind_msg):
+    _ = config_tsun_dcu1
+    m = MemoryStream(dcu_data_ind_msg, (0,))
+    assert 0 == m.db.get_db_value(Register.MAX_DESIGNED_POWER, 0)
+    assert None == m.db.get_db_value(Register.RATED_POWER, None)
+    assert None == m.db.get_db_value(Register.INVERTER_TEMP, None)
+    m.read()         # read complete msg, and dispatch msg
+    assert 0 == m.db.get_db_value(Register.MAX_DESIGNED_POWER, 0)
+    assert 0 == m.db.get_db_value(Register.RATED_POWER, 0)
+    assert 2 == m.db.get_db_value(Register.NO_INPUTS, 0)
+    assert 'TSOL-DC1000' == m.db.get_db_value(Register.EQUIPMENT_MODEL, 0)
+    m.close()
+
+@pytest.mark.asyncio(loop_scope="module")
 async def test_build_logger_modell(my_loop, config_tsun_allow_all, device_ind_msg):
     _ = config_tsun_allow_all
     m = MemoryStream(device_ind_msg, (0,))
@@ -2971,7 +2985,7 @@ async def test_proxy_dcu_cmd(my_loop, config_tsun_dcu1, patch_open_connection, d
         assert l.db.stat['proxy']['AT_Command'] == 0
         assert l.db.stat['proxy']['AT_Command_Blocked'] == 0
         assert l.db.stat['proxy']['Modbus_Command'] == 0
-        assert 2 == l.db.get_db_value(Register.NO_INPUTS, 0)
+        assert 0 == l.db.get_db_value(Register.NO_INPUTS, 0)
 
         l.append_msg(dcu_command_rsp_msg)
         l.read() # read at resp

--- a/ha_addons/templates/README.jinja
+++ b/ha_addons/templates/README.jinja
@@ -4,8 +4,10 @@
 
 ## Features
 
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX450, MX-800 and MX1000
+- Supports TSUN GEN3 PLUS inverters: TSOL-MX3000
 - Supports TSUN GEN3 PLUS inverters: TSOL-MS2000, MS1800 and MS1600
-- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000 (from version 0.13)
+- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000
 - Supports TSUN GEN3 inverters: TSOL-MS3000, MS800, MS700, MS600, MS400, MS350 and MS300
 - `Home-Assistant` auto-discovery support
 - `MODBUS` support via MQTT topics

--- a/ha_addons/templates/README.jinja
+++ b/ha_addons/templates/README.jinja
@@ -4,11 +4,17 @@
 
 ## Features
 
-- Supports TSUN GEN3 PLUS inverters: TSOL-MX450, MX-800 and MX1000
-- Supports TSUN GEN3 PLUS inverters: TSOL-MX3000
-- Supports TSUN GEN3 PLUS inverters: TSOL-MS2000, MS1800 and MS1600
-- Supports TSUN GEN3 PLUS batteries: TSOL-DC1000
-- Supports TSUN GEN3 inverters: TSOL-MS3000, MS800, MS700, MS600, MS400, MS350 and MS300
+- Supports TSUN MX Series:
+  - Microinverter 1-in-1: TSOL-MX500, MX450 and MX400
+  - Microinverter 2-in-1: TSOL-MX1000, MX900 and MX800
+  - Microinverter 4-in-1: TSOL-MX2250
+  - Microinverter 6-in-1: TSOL-MX3300, MX3000, MX2700, MX2500 and MX2400
+- Supports TSUN MS Series:
+  - Microinverter 1-in-1: TSOL-MS400, MS350 and MS300
+  - Microinverter 2-in-1: TSOL-MS800, MS700 and MS600
+  - Microinverter 4-in-1: TSOL-MS2000, MS1800 and MS1600
+- Supports TSUN Batteries:
+  - DCU: TSOL-DC1000
 - `Home-Assistant` auto-discovery support
 - `MODBUS` support via MQTT topics
 - `AT-Command` support via MQTT topics (GEN3PLUS only)


### PR DESCRIPTION
For the MX3000D the pv modules are still not registered at home assistant in v0.16.0-rc2 . The root cause seams to be the missing SolarmanV5 message definitions, which is needed to build the register messages